### PR TITLE
fix: enable SPA routing on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` to rewrite all routes to root so client-side routing works on Vercel

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bac36b6f2c832c9bb5de45272117d9