### PR TITLE
Persist cloud sync timestamp after login

### DIFF
--- a/src/services/__tests__/kikisync.test.ts
+++ b/src/services/__tests__/kikisync.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('@/lib/supabaseClient', () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn().mockResolvedValue({
+        data: { session: { user: { id: 'user1' } } },
+        error: null,
+      }),
+    },
+    rpc: vi.fn().mockResolvedValue({
+      data: { synced_at: '2024-01-01T00:00:00.000Z', pet_id: 'abc123' },
+      error: null,
+    }),
+  },
+}));
+
+vi.mock('@/store', () => ({
+  usePetStore: {
+    getState: () => ({
+      pet: {
+        id: 'pet1',
+        name: 'Kiki',
+        type: 'cat',
+        adoptedAt: 'now',
+        streak: 0,
+        lastTaskDate: null,
+        sessionsCompleted: 0,
+        mutations: [],
+        usedAdRevival: false,
+      },
+      coins: 0,
+      dna: 0,
+      pauseTokens: 0,
+      insurance: false,
+      equippedItems: {},
+      updatePet: vi.fn(),
+      setPet: vi.fn(),
+      setCoins: vi.fn(),
+      setDna: vi.fn(),
+      setPauseTokens: vi.fn(),
+      setInsurance: vi.fn(),
+      removeItem: vi.fn(),
+      equipItem: vi.fn(),
+    }),
+  },
+  useTimerStore: {
+    getState: () => ({
+      sessionStats: {
+        totalSessions: 0,
+        pausesUsed: 0,
+        totalFocusTime: 0,
+        averageSessionLength: 0,
+        longestSession: 0,
+        tasksCompleted: 0,
+        lastSessionDate: null,
+      },
+      updateSessionStats: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('@/utils/logger', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('@/utils/helpers', () => ({
+  setLastCloudSyncToStorage: vi.fn(),
+}));
+
+import { uploadKikiToCloud } from '../kikisync';
+import { setLastCloudSyncToStorage } from '@/utils/helpers';
+
+describe('kikisync', () => {
+  test('uploadKikiToCloud stores sync time on success', async () => {
+    const result = await uploadKikiToCloud();
+    expect(result.success).toBe(true);
+    expect(setLastCloudSyncToStorage).toHaveBeenCalledWith('2024-01-01T00:00:00.000Z');
+  });
+});

--- a/src/services/kikisync.ts
+++ b/src/services/kikisync.ts
@@ -3,6 +3,7 @@ import { usePetStore, useTimerStore } from '@/store';
 import type { Pet } from '@/store';
 import { isValidUuid, generateValidUuid } from '@/utils/uuidFixer';
 import { logger } from '@/utils/logger';
+import { setLastCloudSyncToStorage } from '@/utils/helpers';
 
 /**
  * Wait for a valid Supabase session with retry logic
@@ -156,7 +157,11 @@ export async function uploadKikiToCloud(): Promise<SyncResult> {
     }
 
     logger.info('✅ Pet synced to cloud successfully:', data);
-    
+
+    // Persist last sync time
+    const syncTime = data?.synced_at || new Date().toISOString();
+    setLastCloudSyncToStorage(syncTime);
+
     // Log debug information if available
     if (data?.debug) {
       logger.debug('🐛 Sync debug information:');
@@ -167,7 +172,7 @@ export async function uploadKikiToCloud(): Promise<SyncResult> {
 
     return {
       success: true,
-      synced_at: data.synced_at,
+      synced_at: syncTime,
       pet_id: data.pet_id
     };
 
@@ -277,9 +282,13 @@ export async function downloadKikiFromCloud(): Promise<SyncResult & { data?: Syn
 
     logger.info('✅ Kiki data applied to local stores');
 
+    // Persist last sync time
+    const syncTime = data.synced_at || new Date().toISOString();
+    setLastCloudSyncToStorage(syncTime);
+
     return {
       success: true,
-      synced_at: data.synced_at,
+      synced_at: syncTime,
       data: {
         pet: data.pet,
         stats: data.stats,


### PR DESCRIPTION
## Summary
- track last cloud sync when uploading or downloading Kiki data
- test Kiki sync to ensure sync time is stored

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68bae0b013f4832c90e3df5113ae529d