### PR TITLE
Fix missing cloud sync on initial session

### DIFF
--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -157,7 +157,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           setLoading(false);
           
           // Update user items store on auth changes
-          if (session?.user && event === 'SIGNED_IN') {
+          if (session?.user && (event === 'SIGNED_IN' || event === 'INITIAL_SESSION')) {
             // Download existing Kiki data from cloud first
             try {
               console.log('🔽 Downloading existing Kiki data from cloud...');


### PR DESCRIPTION
## Summary
- sync Kiki data after OAuth redirect by handling INITIAL_SESSION events

## Testing
- `npm test -- --run`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bae4446ba8832cb7b3197dcd63260b